### PR TITLE
Fix Swedish wording for starred messages

### DIFF
--- a/resources/_locales/sv/messages.json
+++ b/resources/_locales/sv/messages.json
@@ -84,7 +84,7 @@
 		"message": "Loggning"
 	},
 	"accountSettingTitle": {
-		"message": "specifika inställningar för kontot §§TITLE§§"
+		"message": "Specifika inställningar för kontot §§TITLE§§"
 	},
 	"toolbarArchive": {
 		"message": "Autoarkivera..."

--- a/resources/_locales/sv/messages.json
+++ b/resources/_locales/sv/messages.json
@@ -45,7 +45,7 @@
 		"message": "Arkivera etiketterade meddelanden (med nyckelord) äldre än "
 	},
 	"archiveStarred": {
-		"message": "Arkivera stjärnmarkerade meddelanden äldre än "
+		"message": "Arkivera stjärnmärkta meddelanden äldre än "
 	},
 	"archiveUnread": {
 		"message": "Arkivera olästa meddelanden äldre än "


### PR DESCRIPTION
Changes “stjärnmarkerade” to the more appropriate Swedish term “stjärnmärkta”.